### PR TITLE
Add VectoredExceptionHandler to prevent the host System from crashing…

### DIFF
--- a/PipeServer/dllmain.cpp
+++ b/PipeServer/dllmain.cpp
@@ -74,12 +74,31 @@ void PipeThread(void*)
 	}
 }
 //---------------------------------------------------------------------------
+LONG CALLBACK VectoredExceptionHandler(PEXCEPTION_POINTERS exceptionPointers)
+{
+	if (exceptionPointers->ExceptionRecord->ExceptionCode == EXCEPTION_INVALID_HANDLE)
+	{
+		return EXCEPTION_CONTINUE_EXECUTION;
+	}
+
+	return EXCEPTION_CONTINUE_SEARCH;
+}
+//---------------------------------------------------------------------------
 BOOL WINAPI DllMain(HMODULE handle, DWORD reason, PVOID reversed)
 {
 	if (reason == DLL_PROCESS_ATTACH)
 	{
+		AddVectoredExceptionHandler(NULL, VectoredExceptionHandler);
+
 		_beginthread(PipeThread, 0, nullptr);
 
+		return TRUE;
+	}
+
+	if (reason == DLL_PROCESS_DETACH)
+	{
+		RemoveVectoredExceptionHandler(VectoredExceptionHandler);
+		
 		return TRUE;
 	}
 


### PR DESCRIPTION
…when injecting into critical System processes with ProcessStrictHandleCheckPolicy.