### PR TITLE
Fix for RemoveWhere extension method

### DIFF
--- a/Plugin/HandleAbuserPluginExt.CoreProcessFunctions.cs
+++ b/Plugin/HandleAbuserPluginExt.CoreProcessFunctions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using ReClassNET.Core;
 using ReClassNET.Debugger;
 using ReClassNET.Util;
+using ReClassNET.Extensions;
 
 namespace HandleAbuserPlugin
 {


### PR DESCRIPTION
EnumerateProcess wasn't able to find the RemoveWhere extension method, so I had to add the "using" directive.